### PR TITLE
Switch to erlef/setup-beam

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: 1.7.0 # Define the elixir version [required]
         otp-version: 22.2 # Define the OTP version [required]


### PR DESCRIPTION
Since `actions/setup-elixir` is no longer supported, this moves to `erlef/setup-beam`.