### PR TITLE
update github actions beam deps

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Setup elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: 1.7.0 # Define the elixir version [required]
-        otp-version: 22.2 # Define the OTP version [required]
+        elixir-version: 1.12.2 # Define the elixir version [required]
+        otp-version: 24 # Define the OTP version [required]
     - name: Install Dependencies
       run: mix deps.get
     - name: Run Tests


### PR DESCRIPTION
Looks like PUID 2.0 requires elixir >= 1.8, so I updated the beam deps accordingly. Hopefully resolves the failing test since it's compiling and tests are running locally for me.